### PR TITLE
Update h1 element with the name of the channel

### DIFF
--- a/src/features/chat/ChatRoom/index.tsx
+++ b/src/features/chat/ChatRoom/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "../service";
 import { auth } from "../../../../lib/firebase.config";
 import ChannelList from "../ChannelList";
-import { useChannels } from "../service";
+import { useChannel } from "../service";
 
 import Button from "@/components/Button";
 import { MdSend } from "react-icons/md";
@@ -32,8 +32,7 @@ export const ChatRoom = (props: IChatRoom) => {
   const [messages, loading, error] = useMessages(activeChannel);
 
   //determine the current channel's name and send it to the h1 element
-  const [channels, channelsLoading, channelsError] = useChannels();
-  const channelName = channels?.docs.map((ch) => ch.data()).find((ch) => ch.id === activeChannel)?.name
+  const [channel, channelsLoading, channelsError] = useChannel(activeChannel);
 
   return (
     <main className="bg-turquoise-200 mx-auto h-screen flex">
@@ -54,7 +53,7 @@ export const ChatRoom = (props: IChatRoom) => {
       </aside>
       <section className="flex flex-auto flex-col items-stretch">
         <div className="h-16 p-4">
-          <h1 className="font-bold text-2xl text-center">{channelName}</h1>
+          <h1 className="font-bold text-2xl text-center">{channel ? channel.name : "Room Name"}</h1>
         </div>
         <div className="flex flex-auto flex-col bg-white rounded-3xl rounded-b-none overflow-hidden p-8 pt-0">
           <div className="flex flex-1 flex-col overflow-y-scroll">

--- a/src/features/chat/ChatRoom/index.tsx
+++ b/src/features/chat/ChatRoom/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "../service";
 import { auth } from "../../../../lib/firebase.config";
 import ChannelList from "../ChannelList";
+import { useChannels } from "../service";
 
 import Button from "@/components/Button";
 import { MdSend } from "react-icons/md";
@@ -29,6 +30,10 @@ export const ChatRoom = (props: IChatRoom) => {
     (router.query.channelId as string) ?? "T415kos6wzfgjKDBpWe3";
 
   const [messages, loading, error] = useMessages(activeChannel);
+
+  //determine the current channel's name and send it to the h1 element
+  const [channels, channelsLoading, channelsError] = useChannels();
+  const channelName = channels?.docs.map((ch) => ch.data()).find((ch) => ch.id === activeChannel)?.name
 
   return (
     <main className="bg-turquoise-200 mx-auto h-screen flex">
@@ -49,7 +54,7 @@ export const ChatRoom = (props: IChatRoom) => {
       </aside>
       <section className="flex flex-auto flex-col items-stretch">
         <div className="h-16 p-4">
-          <h1 className="font-bold text-2xl text-center">Room Name</h1>
+          <h1 className="font-bold text-2xl text-center">{channelName}</h1>
         </div>
         <div className="flex flex-auto flex-col bg-white rounded-3xl rounded-b-none overflow-hidden p-8 pt-0">
           <div className="flex flex-1 flex-col overflow-y-scroll">

--- a/src/features/chat/service.ts
+++ b/src/features/chat/service.ts
@@ -14,7 +14,7 @@ import {
   where,
   serverTimestamp,
 } from "firebase/firestore";
-import { useCollection } from "react-firebase-hooks/firestore";
+import { useCollection, useDocumentData } from "react-firebase-hooks/firestore";
 import { auth, db } from "../../../lib/firebase.config";
 
 export type DataChatMessage = {
@@ -54,6 +54,14 @@ const chatChannelConverter: FirestoreDataConverter<DataChatChannel> = {
       server: data.server,
     };
   },
+};
+
+export const useChannel = (channelId: string) => {
+  const q = doc(db, "channels", channelId).withConverter(chatChannelConverter);
+
+  return useDocumentData<DataChatChannel>(q, {
+    snapshotListenOptions: { includeMetadataChanges: true },
+  });
 };
 
 export const useChannels = () => {


### PR DESCRIPTION
Just a quick change I did before starting work on the actual skeleton screen feature.

BEFORE: H1 element text was fixed to "Room Name"
AFTER: H1 element text is now linked to a variable that holds the current channel name
![image](https://user-images.githubusercontent.com/17146253/226183634-7bac563d-5162-46d7-b439-fb7773367f9a.png)
